### PR TITLE
fix: build with JDK17

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="Boulder Dash" options="--add-exports java.xml/com.sun.org.apache.xml.internal.serialize=ALL-UNNAMED" />
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
On more recent JDK versions, `com.sun.org.apache.xml.internal.serialize` is no longer part of the public interface. With the added compiler option, the game can be built without errors on e.g. JDK17